### PR TITLE
bump pugixml-1.10

### DIFF
--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -144,15 +144,15 @@ if(OGRE_BUILD_DEPENDENCIES AND NOT EXISTS ${OGREDEPS_PATH})
 
     message(STATUS "Building pugixml")
     file(DOWNLOAD
-        https://github.com/zeux/pugixml/releases/download/v1.9/pugixml-1.9.tar.gz
-        ${PROJECT_BINARY_DIR}/pugixml-1.9.tar.gz)
+        https://github.com/zeux/pugixml/releases/download/v1.10/pugixml-1.10.tar.gz
+        ${PROJECT_BINARY_DIR}/pugixml-1.10.tar.gz)
     execute_process(COMMAND ${CMAKE_COMMAND}
-        -E tar xf pugixml-1.9.tar.gz WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+        -E tar xf pugixml-1.10.tar.gz WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
     execute_process(COMMAND ${BUILD_COMMAND_COMMON}
-        ${PROJECT_BINARY_DIR}/pugixml-1.9
-        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/pugixml-1.9)
+        ${PROJECT_BINARY_DIR}/pugixml-1.10
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/pugixml-1.10)
     execute_process(COMMAND ${CMAKE_COMMAND}
-        --build ${PROJECT_BINARY_DIR}/pugixml-1.9 ${BUILD_COMMAND_OPTS})
+        --build ${PROJECT_BINARY_DIR}/pugixml-1.10 ${BUILD_COMMAND_OPTS})
 
     find_package(Freetype)
     if (NOT FREETYPE_FOUND)


### PR DESCRIPTION
Fix Dependencies/lib/libpugixml.a(pugixml.cpp.o): relocation R_X86_64_PC32 against symbol `_ZTVN4pugi15xml_writer_fileE' can not be used when making a shared object; recompile with -fPIC